### PR TITLE
fixed unicode bug in blocking connection

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -507,7 +507,7 @@ class BlockingChannel(channel.Channel):
         if mandatory:
             self._response = None
 
-        if isinstance(body, unicode):
+        if isinstance(body, str):
             body = body.encode('utf-8')
 
         if self._confirmation:


### PR DESCRIPTION
Hi,

there was a line of code in blocking_connection.py (line 510):

if isinstance(body, unicode):

that was causing the error:

global name 'unicode' is not defined

I have changed this to:

if isinstance(body, str):

which fixed the problem.

Please pull,

thanks for your work,

Paul
