### PR TITLE
[ACC-22] improve pika to let tune client properties

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -311,6 +311,7 @@ class ConnectionParameters(Parameters):
     :param int|float socket_timeout: Use for high latency networks
     :param str locale: Set the locale value
     :param bool backpressure_detection: Toggle backpressure detection
+    :param json object client_props: setup your client properties (and overrides the default ones)
 
     """
     def __init__(self,
@@ -327,7 +328,8 @@ class ConnectionParameters(Parameters):
                  retry_delay=None,
                  socket_timeout=None,
                  locale=None,
-                 backpressure_detection=None):
+                 backpressure_detection=None,
+                 client_props=None):
         """Create a new ConnectionParameters instance.
 
         :param str host: Hostname or IP Address to connect to
@@ -344,6 +346,7 @@ class ConnectionParameters(Parameters):
         :param int|float socket_timeout: Use for high latency networks
         :param str locale: Set the locale value
         :param bool backpressure_detection: Toggle backpressure detection
+        :param json object client_props: setup your client properties (and overrides the default ones)
 
         """
         super(ConnectionParameters, self).__init__()
@@ -386,6 +389,7 @@ class ConnectionParameters(Parameters):
         if (backpressure_detection is not None and
             self._validate_backpressure(backpressure_detection)):
             self.backpressure_detection = backpressure_detection
+        self.client_props = client_props
 
 
 class URLParameters(Parameters):
@@ -883,7 +887,7 @@ class Connection(object):
         :rtype: dict
 
         """
-        return {'product': PRODUCT,
+        client_properties = {'product': PRODUCT,
                 'platform': 'Python %s' % platform.python_version(),
                 'capabilities': {'authentication_failure_close': True,
                                  'basic.nack': True,
@@ -892,6 +896,12 @@ class Connection(object):
                                  'publisher_confirms': True},
                 'information': 'See http://pika.rtfd.org',
                 'version': __version__}
+
+        if self.params.client_props is not None:
+             for key in self.params.client_props:
+                 client_properties[key] = self.params.client_props[key]
+
+        return client_properties
 
     def _close_channels(self, reply_code, reply_text):
         """Close the open channels with the specified reply_code and reply_text.


### PR DESCRIPTION
Hello,

I added a little functionality which help you to define the application client properties. eg : 

```
import pika

client_properties = {
    'product': 'my product',
    'information': 'my information',
    'my_other_props': 'my other property',
}

credentials = pika.PlainCredentials('guest', 'guest')
parameters = pika.ConnectionParameters("localhost", 5672, '/',
                                       credentials=credentials, client_props=client_properties)
connection = pika.BlockingConnection(parameters)
```

You'll be then able to differentiate python connections from each other more easily...

Cheers,

Mathilde

![screen shot 2015-05-14 at 11 17 13](https://cloud.githubusercontent.com/assets/5983074/7626712/ff064e1e-fa2a-11e4-9b8f-5e06cc876d36.png)
